### PR TITLE
Locales are not well formed

### DIFF
--- a/lib.lua
+++ b/lib.lua
@@ -263,7 +263,7 @@ function lib.register_plant(plant_name)
 
     -- STEM DEFINITION --
     minetest.register_craftitem(lib.modname .. ":" .. plant_name .."_stem", {
-        description = S(plant_desc) .. S(" Stem"),
+        description = S(plant_desc) .. " " .. S("Stem"),
         inventory_image = lib.modname .. "_".. plant_name .."_stem.png",
         groups = {stem = 1, flammable = 2,},
         --the planting mechanism is in the pot on_rightclick
@@ -875,7 +875,7 @@ function lib.register_fruit_tree (k, sapling_name, full_fruit_name, original_lea
 											end)
 
 	local leaves_def = {
-		description = S(fruit_desc) .. S(" (Leaves)") .. " 1",
+		description = S(fruit_desc) .. " " .. S("(Leaves)") .. " 1",
 		drawtype = "plantlike", -- allfaces_optional
 		visual_scale = 1.3,
 		walkable = false,
@@ -905,7 +905,7 @@ function lib.register_fruit_tree (k, sapling_name, full_fruit_name, original_lea
 
 	-- STAGE 2 : lemon leaves 2 : gives 2-3 lemons, does not grow more, goes back to leaves 1 when harvested
 
-	leaves_def.description = S(fruit_desc) .. S(" (Leaves)") .. " 2"
+	leaves_def.description = S(fruit_desc) .. " " .. S("(Leaves)") .. " 2"
 	leaves_def.tiles = {lib.modname .."_".. fruit_name .."_on_leaves.png^".. leaves_png }
 	leaves_def.drop = {
 		items = {
@@ -947,7 +947,7 @@ function lib.register_fruit_tree (k, sapling_name, full_fruit_name, original_lea
 
 	-- lemon leaves 3 : needs water, does not grow, goes back to leaves 1 when the POT is watered
 
-	leaves_def.description = S(fruit_desc) .. S(" (Leaves)") .. " 3"
+	leaves_def.description = S(fruit_desc) .. " " .. S("(Leaves)") .. " 3"
 	leaves_def.tiles = { leaves_png .. "^[colorize:yellow:35" }
 	leaves_def.drop = {}
 

--- a/locale/potted_farming.de.tr
+++ b/locale/potted_farming.de.tr
@@ -15,7 +15,7 @@ Sage=Salbei
 Parsley=Petersilie
 Mint=Minze
 Oregano=Orig
-Stem=nstiel
+Stem=Stiel
 Wild =Wilde(r)
 
 Brown=Braun

--- a/locale/potted_farming.de.tr
+++ b/locale/potted_farming.de.tr
@@ -15,7 +15,7 @@ Sage=Salbei
 Parsley=Petersilie
 Mint=Minze
 Oregano=Orig
- Stem=nstiel
+Stem=nstiel
 Wild =Wilde(r)
 
 Brown=Braun
@@ -25,7 +25,7 @@ Boletus=Steinpilz
 Lemon=Zitrone
 Orange=Orange
 Apple=Apfel
- (Leaves)= (Blätter)
+(Leaves)=(Blätter)
 
 ### nodes.lua ###
 

--- a/locale/potted_farming.es.tr
+++ b/locale/potted_farming.es.tr
@@ -15,7 +15,7 @@ Sage=Sabio
 Parsley=Perejil
 Mint=Menta
 Oregano=Origan
- Stem= con Raíz
+Stem=con Raíz
 Wild =Salvaje
 
 Brown=Marrón
@@ -25,7 +25,7 @@ Boletus=Boleto
 Lemon=Limón
 Orange=Naranja
 Apple=Manzana
- (Leaves)= (Hojas)
+(Leaves)=(Hojas)
 
 ### nodes.lua ###
 

--- a/locale/potted_farming.fr.tr
+++ b/locale/potted_farming.fr.tr
@@ -16,7 +16,7 @@ Sage=Sauge
 Parsley=Persil
 Mint=Menthe
 Oregano=Origan
- Stem= avec Tige
+# Stem= avec Tige
 Wild =Sauvage
 
 Brown=Brun
@@ -26,7 +26,7 @@ Boletus=Bolet
 Lemon=Citron
 Orange=Orange
 Apple=Pomme
- (Leaves)= (Feuilles)
+# (Leaves)= (Feuilles)
 
 ### nodes.lua ###
 

--- a/locale/potted_farming.it.tr
+++ b/locale/potted_farming.it.tr
@@ -16,7 +16,7 @@ Sage=Salvia
 Parsley=Prezzemolo
 Mint=Menta
 Oregano=Origano
- Stem= con Radice
+Stem=con Radice
 Wild =Selvatico
 
 Brown=Marrone
@@ -26,7 +26,7 @@ Boletus=Boleto
 Lemon=Limone
 Orange=Arancia
 Apple=Mela
- (Leaves)= (Foglie)
+(Leaves)=(Foglie)
 
 ### nodes.lua ###
 

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -16,7 +16,7 @@ Sage=
 Parsley=
 Mint=
 Oregano=
- Stem=
+Stem=
 Wild =
 
 Brown=
@@ -26,7 +26,7 @@ Boletus=
 Lemon=
 Orange=
 Apple=
- (Leaves)=
+(Leaves)=
 
 ### nodes.lua ###
 


### PR DESCRIPTION
Very simple mistake: translation string seems to emit lot of warnings when beginning with " "
I just prefixed the string with " " then call translator and fixed locale.
Also there was a typo in one German translation.

P.S.: nodes over pots should not be buildable, that may be prevented in on_rightclick checking
pointer.above.y ~= pointer.under.y + 1